### PR TITLE
apiv2: add HiveOS GPU (SRBMiner) API support

### DIFF
--- a/src/mod/apiv2/client.py
+++ b/src/mod/apiv2/client.py
@@ -20,6 +20,7 @@ from mod.apiv2.data.miners import (
     IceriverParser,
     LuxminerParser,
     SealminerParser,
+    SRBMinerParser,
     VnishParser,
     VolcminerParser,
     WhatsminerParser,
@@ -38,6 +39,7 @@ from mod.apiv2.http import (
     GoldshellHTTPClient,
     IceriverHTTPClient,
     SealminerHTTPClient,
+    SRBMinerHTTPClient,
     VnishHTTPClient,
     VolcminerHTTPClient,
 )
@@ -121,6 +123,9 @@ class ASICClient(QObject):
     def create_auradine_client(self, ip: str, alt_pwd: str | None = None) -> None:
         self._set_active_client(AuradineHTTPClient(ip, alt_pwd=alt_pwd))
 
+    def create_hivegpu_client(self, ip: str, alt_pwd: str | None = None) -> None:
+        self._set_active_client(SRBMinerHTTPClient(ip, alt_pwd=alt_pwd))
+
     def create_client(
         self, miner_type: MinerType, ip: str, alt_pwd: str | None = None
     ) -> None:
@@ -147,6 +152,8 @@ class ASICClient(QObject):
                 self.create_vnish_client(ip, alt_pwd=alt_pwd)
             case MinerType.AURADINE:
                 self.create_auradine_client(ip, alt_pwd=alt_pwd)
+            case MinerType.HIVEGPU:
+                self.create_hivegpu_client(ip, alt_pwd=alt_pwd)
             case _:
                 # type is unknown or not supported
                 self.client = None
@@ -211,6 +218,8 @@ class ASICClient(QObject):
             return self._parse_miner_data(LuxminerParser())
         elif isinstance(self.client, AuradineHTTPClient):
             return self._parse_miner_data(AuradineParser())
+        elif isinstance(self.client, SRBMinerHTTPClient):
+            return self._parse_miner_data(SRBMinerParser())
         return MinerData().as_dict()
 
     def _parse_miner_data(self, parser: BaseParser) -> dict[str, Any]:
@@ -232,6 +241,10 @@ class ASICClient(QObject):
                 or isinstance(parser, AuradineParser)
             ):
                 parser.parse_all(system_info)
+            elif isinstance(parser, SRBMinerParser):
+                parser.parse_all(system_info)
+                # uptime is not part of the generic parse_all() sequence.
+                parser.parse_uptime(system_info)
             elif isinstance(parser, GoldshellParser):
                 parser.parse_system_info(system_info)
                 settings = self.client.get_miner_conf()

--- a/src/mod/apiv2/data/__init__.py
+++ b/src/mod/apiv2/data/__init__.py
@@ -67,6 +67,7 @@ class MinerAlgorithm(str, Enum):
     ETHASH = "EtHash"
     EQUIHASH = "Equihash"
     RANDOMX = "RandomX"
+    PEARLHASH = "Pearlhash"
 
     def __str__(self) -> str:
         return self.value

--- a/src/mod/apiv2/data/miners/__init__.py
+++ b/src/mod/apiv2/data/miners/__init__.py
@@ -10,6 +10,7 @@ from .goldshell import GoldshellParser
 from .iceriver import IceriverParser
 from .luxminer import LuxminerParser
 from .sealminer import SealminerParser
+from .srbminer import SRBMinerParser
 from .vnish import VnishParser
 from .volcminer import VolcminerParser
 from .whatsminer import WhatsminerParser, WhatsminerV3Parser

--- a/src/mod/apiv2/data/miners/srbminer.py
+++ b/src/mod/apiv2/data/miners/srbminer.py
@@ -1,0 +1,93 @@
+# Copyright (C) 2024-2026 Matthew Wertman <matt@bitcap.co>
+#
+# This file is part of bitcap-ipr
+# Licensed under the GNU General Public License v3.0; see LICENSE
+
+from typing import Any
+
+from mod.apiv2.data import BaseParser, MinerAlgorithm, MinerType
+
+# marketing/vendor tokens stripped when building a readable GPU model name.
+_GPU_MODEL_NOISE = {"nvidia", "amd", "intel", "geforce", "radeon"}
+
+
+def _format_gpu_model(model: str) -> str:
+    """Turn an SRBMiner device model into a readable name.
+
+    e.g. "nvidia_geforce_rtx_3070" -> "RTX 3070".
+    """
+    parts = [p for p in model.split("_") if p and p.lower() not in _GPU_MODEL_NOISE]
+    if not parts:
+        parts = [p for p in model.split("_") if p]
+    cleaned: list[str] = []
+    for p in parts:
+        # short alpha tokens are acronyms (rtx, gtx, rx); keep numbers as-is.
+        if p.isalpha() and len(p) <= 3:
+            cleaned.append(p.upper())
+        elif p.isalpha():
+            cleaned.append(p.capitalize())
+        else:
+            cleaned.append(p)
+    return " ".join(cleaned)
+
+
+class SRBMinerParser(BaseParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.data.type = MinerType.HIVEGPU
+        self.data.platform = "HiveOS"
+
+    def parse_api_version(self, obj: dict[str, Any]) -> None:
+        self.data.api_version = obj["miner_version"]
+
+    def parse_uptime(self, obj: dict[str, Any]) -> None:
+        self.data.uptime = obj["mining_time"]
+
+    def parse_hostname(self, obj: dict[str, Any]) -> None:
+        self.data.hostname = obj["rig_name"]
+
+    def parse_mac(self, obj: Any) -> None:
+        # not exposed by the SRBMiner API; filled from the IP Report.
+        return super().parse_mac(obj)
+
+    def parse_serial(self, obj: Any) -> None:
+        return super().parse_serial(obj)
+
+    def parse_type(self, obj: Any) -> None:
+        return super().parse_type(obj)
+
+    def parse_subtype(self, obj: dict[str, Any]) -> None:
+        # report as "Nx GPU_MODEL" (e.g. "4x RTX 3070").
+        gpus = obj["gpu_devices"]
+        if not gpus:
+            return
+        count = obj["total_gpu_workers"] or len(gpus)
+        model = _format_gpu_model(gpus[0]["model"])
+        self.data.subtype = f"{count}x {model}" if model else f"{count}x GPU"
+
+    def parse_algorithm(self, obj: dict[str, Any]) -> None:
+        algos = obj["algorithms"]
+        if algos:
+            self.data.algorithm = MinerAlgorithm.from_value(algos[0]["name"])
+
+    def parse_firmware(self, obj: dict[str, Any]) -> None:
+        return super().parse_firmware(obj)
+
+    def parse_platform(self, obj: Any) -> None:
+        return super().parse_platform(obj)
+
+    def parse_system_info(self, obj: Any) -> None:
+        return super().parse_system_info(obj)
+
+    def parse_pools(self, obj: list[dict[str, Any]]) -> None:
+        for pool in obj:
+            if not pool.get("url"):
+                continue
+            self.data.stratum_url = pool["url"]
+            if "." in pool["user"]:
+                user, worker = pool["user"].split(".", 1)
+                self.data.username = user
+                self.data.worker_name = worker
+            else:
+                self.data.username = pool["user"]
+            break

--- a/src/mod/apiv2/http/__init__.py
+++ b/src/mod/apiv2/http/__init__.py
@@ -9,5 +9,6 @@ from .elphapex import ElphapexHTTPClient
 from .goldshell import GoldshellHTTPClient
 from .iceriver import IceriverHTTPClient
 from .sealminer import SealminerHTTPClient
+from .srbminer import SRBMinerHTTPClient
 from .vnish import VnishHTTPClient
 from .volcminer import VolcminerHTTPClient

--- a/src/mod/apiv2/http/srbminer.py
+++ b/src/mod/apiv2/http/srbminer.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2024-2026 Matthew Wertman <matt@bitcap.co>
+#
+# This file is part of bitcap-ipr
+# Licensed under the GNU General Public License v3.0; see LICENSE
+
+import logging
+from string import Template
+
+from pydantic import BaseModel, ValidationError
+
+from mod.apiv2.base import BaseHTTPClient
+from mod.apiv2.errors import APIError, APIInvalidResponse
+
+logger = logging.getLogger(__name__)
+
+
+class GPUDevice(BaseModel):
+    device: str = ""
+    vendor: str = ""
+    model: str = ""
+
+
+class SRBPool(BaseModel):
+    pool: str = ""
+    wallet: str = ""
+
+
+class SRBAlgorithm(BaseModel):
+    name: str = ""
+    pool: SRBPool = SRBPool()
+
+
+class SRBMinerInfo(BaseModel):
+    rig_name: str = ""
+    miner_version: str = ""
+    mining_time: int = 0
+    total_cpu_workers: int = 0
+    total_gpu_workers: int = 0
+    gpu_devices: list[GPUDevice] = []
+    algorithms: list[SRBAlgorithm] = []
+
+
+class SRBMinerHTTPClient(BaseHTTPClient):
+    """HTTP client for HiveOS GPU rigs via the SRBMiner-MULTI remote API.
+
+    SRBMiner exposes a read-only JSON status endpoint on port 21550 by default.
+    The API is unauthenticated, so requests are issued directly.
+    """
+
+    def __init__(self, ip: str, port: int = 21550, alt_pwd: str | None = None) -> None:
+        super().__init__(ip, port, alt_pwd)
+        # SRBMiner's remote API is read-only and unauthenticated.
+        self.authed = True
+        self.command_path = Template("${command}")
+
+    def authenticate(self) -> None:
+        # nothing to authenticate against; the API is open.
+        self.authed = True
+
+    def get_hostname(self) -> str:
+        return self.get_system_info()["rig_name"]
+
+    def get_mac_addr(self) -> str:
+        # not exposed by the SRBMiner API; MAC comes from the IP Report.
+        return super().get_mac_addr()
+
+    def get_api_version(self) -> str:
+        return self.get_system_info()["miner_version"]
+
+    def get_system_info(self) -> dict:
+        resp = self.send_command("GET", command="")
+        try:
+            info = SRBMinerInfo.model_validate(obj=resp)
+        except ValidationError as e:
+            logger.error(
+                f"{self.__repr__()} : {str(APIInvalidResponse(reason=str(e)))}"
+            )
+            raise APIInvalidResponse
+        else:
+            return info.model_dump()
+
+    def get_network_info(self) -> dict:
+        return super().get_network_info()
+
+    def log(self, *args, **kwargs) -> dict:
+        return super().log(*args, **kwargs)
+
+    def summary(self) -> dict:
+        return self.get_system_info()
+
+    def get_miner_conf(self) -> dict:
+        return super().get_miner_conf()
+
+    def set_miner_conf(self, *args, **kwargs) -> dict:
+        return super().set_miner_conf(*args, **kwargs)
+
+    def pools(self) -> list[dict]:
+        info = self.get_system_info()
+        pools: list[dict] = []
+        for algo in info["algorithms"]:
+            pool = algo["pool"]
+            if pool["pool"]:
+                pools.append({"url": pool["pool"], "user": pool["wallet"]})
+        return pools
+
+    def get_pool_conf(self) -> list[dict]:
+        return self.pools()
+
+    def get_miner_status(self) -> dict:
+        return super().get_miner_status()
+
+    def get_blink_status(self) -> dict:
+        return super().get_blink_status()
+
+    def blink(self, enabled: bool, *args, **kwargs) -> dict:
+        # GPU rigs have no locate LED to toggle.
+        raise APIError("Locate is not supported for HiveOS GPU rigs")
+
+    def update_pool_conf(
+        self, urls: list[str], users: list[str], passwds: list[str]
+    ) -> dict:
+        raise APIError("Pool configuration is not supported for HiveOS GPU rigs")

--- a/src/tests/payloads/srbminer.json
+++ b/src/tests/payloads/srbminer.json
@@ -1,0 +1,143 @@
+{
+  "rig_name": "SRBMiner-Multi-Rig",
+  "miner_version": "3.3.7",
+  "mining_time": 147714,
+  "total_cpu_workers": 0,
+  "total_gpu_workers": 4,
+  "total_workers": 4,
+  "cpu_devices": [
+    {
+      "id": 0,
+      "device": "cpu0",
+      "model": "Intel(R) Celeron(R) CPU G3930 @ 2.90GHz",
+      "L3": 2097152,
+      "L2": 524288,
+      "L1": 65536
+    }
+  ],
+  "gpu_devices": [
+    {
+      "id": 0,
+      "topology_id": "0000:01:00.0",
+      "bus_id": 1,
+      "device": "gpu0",
+      "vendor": "nvidia",
+      "model": "nvidia_geforce_rtx_3070",
+      "fan_speed_percent": 100,
+      "core_clock": 1305,
+      "memory_clock": 7800,
+      "temperature": 68,
+      "asic_power": 171,
+      "off_temperature": 100
+    },
+    {
+      "id": 1,
+      "topology_id": "0000:03:00.0",
+      "bus_id": 3,
+      "device": "gpu1",
+      "vendor": "nvidia",
+      "model": "nvidia_geforce_rtx_3070",
+      "fan_speed_percent": 100,
+      "core_clock": 1305,
+      "memory_clock": 7800,
+      "temperature": 63,
+      "asic_power": 163,
+      "off_temperature": 100
+    },
+    {
+      "id": 2,
+      "topology_id": "0000:04:00.0",
+      "bus_id": 4,
+      "device": "gpu2",
+      "vendor": "nvidia",
+      "model": "nvidia_geforce_rtx_3070",
+      "fan_speed_percent": 100,
+      "core_clock": 1305,
+      "memory_clock": 7800,
+      "temperature": 70,
+      "asic_power": 168,
+      "off_temperature": 100
+    },
+    {
+      "id": 3,
+      "topology_id": "0000:05:00.0",
+      "bus_id": 5,
+      "device": "gpu3",
+      "vendor": "nvidia",
+      "model": "nvidia_geforce_rtx_3070",
+      "fan_speed_percent": 100,
+      "core_clock": 1305,
+      "memory_clock": 7800,
+      "temperature": 86,
+      "asic_power": 183,
+      "off_temperature": 100
+    }
+  ],
+  "algorithms": [
+    {
+      "id": 0,
+      "name": "pearlhash",
+      "pool": {
+        "pool": "us2.pearl.herominers.com:1200",
+        "wallet": "prl1xxxxxxxx.4x",
+        "time_connected": "2026-06-20 11:07:36",
+        "uptime": 147712,
+        "difficulty": 0.987,
+        "last_job_received": 269,
+        "latency": 246
+      },
+      "shares": {
+        "total": 2137,
+        "accepted": 2129,
+        "rejected": 8,
+        "avg_find_time": 69
+      },
+      "hashrate": {
+        "1min": 228131658910186.56,
+        "1hr": 227535394142388.75,
+        "6hr": 217193360986162.53,
+        "12hr": 213179792894369.88,
+        "cpu": {
+          "total": 0.0
+        },
+        "gpu": {
+          "gpu0": 57163468486147.54,
+          "gpu1": 57168809156323.78,
+          "gpu2": 57162354037352.37,
+          "gpu3": 56181867533665.41,
+          "total": 227676499213489.1
+        }
+      },
+      "gpu_accepted_shares": {
+        "gpu0": 567,
+        "gpu1": 522,
+        "gpu2": 531,
+        "gpu3": 509
+      },
+      "gpu_rejected_shares": {
+        "gpu0": 1,
+        "gpu1": 1,
+        "gpu2": 2,
+        "gpu3": 4
+      },
+      "gpu_compute_errors": {
+        "gpu0": 0,
+        "gpu1": 0,
+        "gpu2": 0,
+        "gpu3": 0
+      },
+      "gpu_efficiency": {
+        "gpu0": 334289289392.68,
+        "gpu1": 350728890529.59,
+        "gpu2": 340252107365.19,
+        "gpu3": 307004740621.12
+      },
+      "gpu_autotune_results": {
+        "gpu0": "0",
+        "gpu1": "0",
+        "gpu2": "0",
+        "gpu3": "0"
+      }
+    }
+  ]
+}

--- a/src/tests/test_srbminer_parser.py
+++ b/src/tests/test_srbminer_parser.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2024-2026 Matthew Wertman <matt@bitcap.co>
+#
+# This file is part of bitcap-ipr
+# Licensed under the GNU General Public License v3.0; see LICENSE
+
+import json
+import unittest
+from pathlib import Path
+
+from mod.apiv2.data import MinerAlgorithm, MinerType
+from mod.apiv2.data.miners.srbminer import SRBMinerParser, _format_gpu_model
+from mod.apiv2.http.srbminer import SRBMinerInfo
+
+
+def read_payload(filename: str) -> dict:
+    with open(Path(filename).resolve(), "r") as f:
+        return json.load(f)
+
+
+class TestFormatGPUModel(unittest.TestCase):
+    def test_strips_vendor_and_uppercases_acronym(self):
+        self.assertEqual(_format_gpu_model("nvidia_geforce_rtx_3070"), "RTX 3070")
+
+    def test_amd_radeon(self):
+        self.assertEqual(_format_gpu_model("amd_radeon_rx_6800"), "RX 6800")
+
+    def test_all_noise_falls_back_to_raw_tokens(self):
+        # if every token is filtered, fall back rather than returning empty
+        self.assertEqual(_format_gpu_model("nvidia"), "Nvidia")
+
+
+class TestSRBMinerParser(unittest.TestCase):
+    def setUp(self):
+        self.payload = read_payload("tests/payloads/srbminer.json")
+        # normalize through the client's model the same way the client does
+        self.info = SRBMinerInfo.model_validate(self.payload).model_dump()
+        self.parser = SRBMinerParser()
+        self.parser.parse_all(self.info)
+        self.parser.parse_uptime(self.info)
+
+    def test_type_and_platform(self):
+        data = self.parser.get_data()
+        self.assertEqual(data["type"], str(MinerType.HIVEGPU))
+        self.assertEqual(data["platform"], "HiveOS")
+
+    def test_subtype_is_count_and_model(self):
+        self.assertEqual(self.parser.get_data()["subtype"], "4x RTX 3070")
+
+    def test_version_and_hostname_and_uptime(self):
+        data = self.parser.get_data()
+        # SRBMiner version is reported as the API version; the rig firmware
+        # version is not exposed by the API.
+        self.assertEqual(data["api_version"], "3.3.7")
+        self.assertEqual(data["hostname"], "SRBMiner-Multi-Rig")
+        self.assertEqual(data["uptime"], self.payload["mining_time"])
+
+    def test_algorithm(self):
+        # pearlhash resolves to the MinerAlgorithm added for GPU rigs
+        self.assertEqual(self.parser.get_data()["algorithm"], str(MinerAlgorithm.PEARLHASH))
+
+    def test_pools(self):
+        pools = [
+            {"url": algo["pool"]["pool"], "user": algo["pool"]["wallet"]}
+            for algo in self.info["algorithms"]
+            if algo["pool"]["pool"]
+        ]
+        self.parser.parse_pools(pools)
+        data = self.parser.get_data()
+        self.assertEqual(
+            data["stratum_url"], self.payload["algorithms"][0]["pool"]["pool"]
+        )
+        # wallet.worker is split into username/worker_name
+        wallet = self.payload["algorithms"][0]["pool"]["wallet"]
+        self.assertEqual(data["username"], wallet.split(".", 1)[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add API support for HiveOS GPU rigs (MinerType.HIVEGPU) via the SRBMiner-MULTI remote API on port 21550.

- SRBMinerHTTPClient: read-only, unauthenticated JSON client validated through the SRBMinerInfo model.
- SRBMinerParser: maps the SRBMiner payload to MinerData, reporting the subtype as "Nx GPU_MODEL" (e.g. "4x RTX 3070") and platform "HiveOS". SRBMiner version is surfaced as the API version; MAC/IP come from the IP Report. Locate and pool config are unsupported for GPU rigs.
- Wire HIVEGPU into ASICClient create/dispatch/parse paths.
- Add the Pearlhash algorithm and an offline parser test with a captured SRBMiner payload fixture.

The miner type stays HiveGPU (create_hivegpu_client) while the API client and parser are named for the SRBMiner software, since other software may run on HiveOS in the future.